### PR TITLE
add module Data.ObjectMap.ST

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Map-like data structure with stable insertion order
 
 ## Description
 
-An `ObjectMap k v` represents maps from keys of type k to values of type v. It _keeps its insertion order_ and has efficient lookups. The insertion performance however is O(n), equal to the underlying [Object](https://pursuit.purescript.org/packages/purescript-foreign-object).
+An `ObjectMap k v` represents maps from keys of type k to values of type v. It _keeps its insertion order_ and has efficient lookups. The insertion performance however is O(n), equal to the underlying [Object](https://pursuit.purescript.org/packages/purescript-foreign-object) but there's also an `ST` version available with constant insertion performance.
 
 Keys need an instance of [EncodeJson](https://pursuit.purescript.org/packages/purescript-argonaut-codecs/docs/Data.Argonaut.Encode.Class#t:EncodeJson) for most operations.
 
@@ -35,12 +35,11 @@ import Data.ObjectMap (ObjectMap)
 import Data.ObjectMap.ST as STOM
 
 sample :: ObjectMap Int String
-sample = ST.run (do
-          m <- STOM.new
-          for_ (1..10000) \n -> do
-            void $ STOM.poke i (show i) m
-          STOM.unsafeFreeze m
-)
+sample = ST.run do
+  m <- STOM.new
+  for_ (1..10000) \n -> do
+    void $ STOM.poke i (show i) m
+  STOM.unsafeFreeze m
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -26,6 +26,23 @@ The REPL output shows that the order is preserved.
 [(Tuple 2 "2"),(Tuple 3 "3"),(Tuple 1 "1")]
 ```
 
+As previously said, `insert` has O(n) time complexity. If you want better performance, you can use the function
+`poke` of the module `Data.ObjectMap.ST` which has O(1) average time complexity.
+
+```hs
+import Control.Monad.ST as ST
+import Data.ObjectMap (ObjectMap)
+import Data.ObjectMap.ST as STOM
+
+sample :: ObjectMap Int String
+sample = ST.run (do
+          m <- STOM.new
+          for_ (1..10000) \n -> do
+            void $ STOM.poke i (show i) m
+          STOM.unsafeFreeze m
+)
+```
+
 ## FAQ
 
 ### Isn't it unsafe to rely on JavaScripts Object property order?

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,19 +1,15 @@
 { name = "object-maps"
 , dependencies =
-  [ "aff"
-  , "argonaut-codecs"
+  [ "argonaut-codecs"
   , "argonaut-core"
-  , "datetime"
-  , "debug"
-  , "effect"
   , "either"
   , "foreign-object"
   , "maybe"
   , "prelude"
   , "profunctor-lenses"
-  , "spec"
+  , "st"
   , "tuples"
   ]
 , packages = ./packages.dhall
-, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+, sources = [ "src/**/*.purs" ]
 }

--- a/src/Data/ObjectMap.purs
+++ b/src/Data/ObjectMap.purs
@@ -1,73 +1,9 @@
 module Data.ObjectMap
-  ( ObjectMap(..)
-  , delete
-  , empty
-  , fromArray
-  , insert
-  , lookup
-  , toArray
-  , toJsonStr
+  ( module I
   , module Exp
-  ) where
-
-import Prelude
-
-import Data.Argonaut.Core (stringify)
-import Data.Argonaut.Encode (class EncodeJson, encodeJson) as Exp
-import Data.Argonaut.Encode (class EncodeJson, encodeJson)
-import Data.Either (Either(..))
-import Data.Lens (lens)
-import Data.Lens.AffineTraversal (affineTraversal)
-import Data.Lens.At (class At)
-import Data.Lens.Index (class Index)
-import Data.Maybe (Maybe, maybe, maybe')
-import Data.Tuple (Tuple(..), fst, snd)
-import Data.Tuple.Nested ((/\))
-import Foreign.Object (Object)
-import Foreign.Object as Obj
-
-newtype ObjectMap k v = ObjectMap (Object (Tuple k v))
-
-fromArray :: forall k v. EncodeJson k => Array (Tuple k v) -> ObjectMap k v
-fromArray xs = xs
-  <#> (\kv -> toJsonStr (fst kv) /\ kv)
-  # Obj.fromFoldable
-  # ObjectMap
-
-toArray :: forall k v. ObjectMap k v -> Array (Tuple k v)
-toArray (ObjectMap obj) = Obj.values obj
-
-empty :: forall k v. ObjectMap k v
-empty = ObjectMap $ Obj.empty
-
-insert :: forall k v. EncodeJson k => k -> v -> ObjectMap k v -> ObjectMap k v
-insert key val (ObjectMap obj) = ObjectMap $
-  Obj.insert (toJsonStr key) (Tuple key val) obj
-
-delete :: forall k v. EncodeJson k => k -> ObjectMap k v -> ObjectMap k v
-delete key (ObjectMap obj) = ObjectMap $ Obj.delete (toJsonStr key) obj
-
-lookup :: forall k v. EncodeJson k => k -> ObjectMap k v -> Maybe v
-lookup key (ObjectMap obj) = Obj.lookup (toJsonStr key) obj <#> snd
-
-instance EncodeJson k => Index (ObjectMap k v) k v where
-  ix k = affineTraversal set pre
-    where
-    set :: ObjectMap k v -> v -> ObjectMap k v
-    set s b = insert k b s
-
-    pre :: ObjectMap k v -> Either (ObjectMap k v) v
-    pre s = maybe (Left s) Right $ lookup k s
-
-instance EncodeJson k => At (ObjectMap k v) k v where
-  at k =
-    lens (lookup k) \m ->
-      maybe' (\_ -> delete k m) \v -> insert k v m
-
-toJsonStr :: forall a. EncodeJson a => a -> String
-toJsonStr = encodeJson >>> stringify >>> enforceJsString
-
-enforceJsString :: String -> String
-enforceJsString x = ticks <> x <> ticks
+  )
   where
-  ticks = "\""
+
+import Data.Argonaut.Encode (class EncodeJson, encodeJson) as Exp
+import Data.ObjectMap.Internal (ObjectMap, empty, fromArray, toArray, lookup, insert, delete) as I
+

--- a/src/Data/ObjectMap.purs
+++ b/src/Data/ObjectMap.purs
@@ -1,11 +1,12 @@
 module Data.ObjectMap
-  ( ObjectMap
+  ( ObjectMap(..)
   , delete
   , empty
   , fromArray
   , insert
   , lookup
   , toArray
+  , toJsonStr
   , module Exp
   ) where
 

--- a/src/Data/ObjectMap/Internal.purs
+++ b/src/Data/ObjectMap/Internal.purs
@@ -1,0 +1,63 @@
+module Data.ObjectMap.Internal where
+
+import Prelude
+import Data.Argonaut.Core (stringify)
+import Data.Argonaut.Encode (class EncodeJson, encodeJson)
+import Data.Either (Either(..))
+import Data.Lens (lens)
+import Data.Lens.AffineTraversal (affineTraversal)
+import Data.Lens.At (class At)
+import Data.Lens.Index (class Index)
+import Data.Maybe (Maybe, maybe, maybe')
+import Data.Tuple (Tuple(..), fst, snd)
+import Data.Tuple.Nested ((/\))
+import Foreign.Object (Object)
+import Foreign.Object as Obj
+
+
+newtype ObjectMap k v = ObjectMap (Object (Tuple k v))
+
+fromArray :: forall k v. EncodeJson k => Array (Tuple k v) -> ObjectMap k v
+fromArray xs = xs
+  <#> (\kv -> toJsonStr (fst kv) /\ kv)
+  # Obj.fromFoldable
+  # ObjectMap
+
+toArray :: forall k v. ObjectMap k v -> Array (Tuple k v)
+toArray (ObjectMap obj) = Obj.values obj
+
+empty :: forall k v. ObjectMap k v
+empty = ObjectMap $ Obj.empty
+
+insert :: forall k v. EncodeJson k => k -> v -> ObjectMap k v -> ObjectMap k v
+insert key val (ObjectMap obj) = ObjectMap $
+  Obj.insert (toJsonStr key) (Tuple key val) obj
+
+
+delete :: forall k v. EncodeJson k => k -> ObjectMap k v -> ObjectMap k v
+delete key (ObjectMap obj) = ObjectMap $ Obj.delete (toJsonStr key) obj
+
+lookup :: forall k v. EncodeJson k => k -> ObjectMap k v -> Maybe v
+lookup key (ObjectMap obj) = Obj.lookup (toJsonStr key) obj <#> snd
+
+instance EncodeJson k => Index (ObjectMap k v) k v where
+  ix k = affineTraversal set pre
+    where
+    set :: ObjectMap k v -> v -> ObjectMap k v
+    set s b = insert k b s
+
+    pre :: ObjectMap k v -> Either (ObjectMap k v) v
+    pre s = maybe (Left s) Right $ lookup k s
+
+instance EncodeJson k => At (ObjectMap k v) k v where
+  at k =
+    lens (lookup k) \m ->
+      maybe' (\_ -> delete k m) \v -> insert k v m
+
+toJsonStr :: forall a. EncodeJson a => a -> String
+toJsonStr = encodeJson >>> stringify >>> enforceJsString
+
+enforceJsString :: String -> String
+enforceJsString x = ticks <> x <> ticks
+  where
+  ticks = "\""

--- a/src/Data/ObjectMap/ST.purs
+++ b/src/Data/ObjectMap/ST.purs
@@ -1,0 +1,35 @@
+module Data.ObjectMap.ST where
+
+import Prelude
+
+import Control.Monad.ST (ST)
+import Data.Argonaut.Encode (class EncodeJson)
+import Data.Maybe (Maybe)
+import Data.ObjectMap as OM
+import Data.Tuple (Tuple, snd)
+import Data.Tuple.Nested ((/\))
+import Foreign.Object.ST (STObject)
+import Foreign.Object.ST as STO
+import Foreign.Object.ST.Unsafe as STOU
+
+newtype STObjectMap r k v = STObjectMap (STObject r (Tuple k v))
+
+-- | Create a new, empty mutable map
+new :: forall r k v. ST r (STObjectMap r k v)
+new = STObjectMap <$> STO.new
+
+-- | Get the value for a key in a mutable map
+peek :: forall r k v. EncodeJson k => k -> STObjectMap r k v -> ST r (Maybe v)
+peek k (STObjectMap m) = map snd <$> STO.peek (OM.toJsonStr k) m
+
+-- | Update the value for a key in a mutable map
+poke :: forall r k v. EncodeJson k => k -> v -> STObjectMap r k v -> ST r (STObjectMap r k v)
+poke k v (STObjectMap m) = STObjectMap <$> STO.poke (OM.toJsonStr k) (k /\ v) m
+
+-- | Remove a key and the corresponding value from a mutable map
+delete :: forall r k v. EncodeJson k => k -> STObjectMap r k v -> ST r (STObjectMap r k v)
+delete k (STObjectMap m) = STObjectMap <$> STO.delete (OM.toJsonStr k) m
+
+-- | Unsafely get the map out of ST without copying it
+unsafeFreeze :: forall r k v. STObjectMap r k v -> ST r (OM.ObjectMap k v)
+unsafeFreeze (STObjectMap m) = OM.ObjectMap <$> STOU.unsafeFreeze m

--- a/src/Data/ObjectMap/ST.purs
+++ b/src/Data/ObjectMap/ST.purs
@@ -5,7 +5,7 @@ import Prelude
 import Control.Monad.ST (ST)
 import Data.Argonaut.Encode (class EncodeJson)
 import Data.Maybe (Maybe)
-import Data.ObjectMap as OM
+import Data.ObjectMap.Internal as OM
 import Data.Tuple (Tuple, snd)
 import Data.Tuple.Nested ((/\))
 import Foreign.Object.ST (STObject)

--- a/src/Data/ObjectMap/ST.purs
+++ b/src/Data/ObjectMap/ST.purs
@@ -1,4 +1,12 @@
-module Data.ObjectMap.ST where
+module Data.ObjectMap.ST
+  ( STObjectMap
+  , delete
+  , new
+  , peek
+  , poke
+  , unsafeFreeze
+  )
+  where
 
 import Prelude
 

--- a/test.dhall
+++ b/test.dhall
@@ -1,0 +1,5 @@
+let conf = ./spago.dhall
+in conf // {
+  sources = conf.sources # [ "test/**/*.purs" ],
+  dependencies = conf.dependencies # [ "aff", "effect", "spec" ]
+}

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,14 +2,14 @@ module Test.Main where
 
 import Prelude
 
+import Control.Monad.ST (run)
 import Data.ObjectMap (ObjectMap)
 import Data.ObjectMap as OM
-import Data.Time.Duration (Milliseconds(..))
+import Data.ObjectMap.ST as STOM
 import Data.Tuple.Nested ((/\))
-import Debug (spy)
 import Effect (Effect)
-import Effect.Aff (launchAff_, delay)
-import Test.Spec (pending, describe, it)
+import Effect.Aff (launchAff_)
+import Test.Spec (describe, it)
 import Test.Spec.Assertions (shouldEqual)
 import Test.Spec.Reporter.Console (consoleReporter)
 import Test.Spec.Runner (runSpec)
@@ -45,5 +45,20 @@ main = launchAff_ $ runSpec [ consoleReporter ] do
         # shouldEqual
             [ 2 /\ 2
             , 3 /\ 3
+            , 1 /\ 1
+            ]
+
+  describe "build an object map via ST" do
+    it "keeps order" do
+      let m' = run (do
+            m <- STOM.new
+            _ <- STOM.poke 2 3 m
+            _ <- STOM.poke 3 3 m
+            _ <- STOM.poke 1 1 m
+            _ <- STOM.delete 3 m
+            STOM.unsafeFreeze m
+      )
+      OM.toArray m' # shouldEqual
+            [ 2 /\ 3
             , 1 /\ 1
             ]

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -55,10 +55,10 @@ main = launchAff_ $ runSpec [ consoleReporter ] do
             _ <- STOM.poke 2 3 m
             _ <- STOM.poke 3 3 m
             _ <- STOM.poke 1 1 m
-            _ <- STOM.delete 3 m
             STOM.unsafeFreeze m
       )
       OM.toArray m' # shouldEqual
             [ 2 /\ 3
+            , 3 /\ 3
             , 1 /\ 1
             ]


### PR DESCRIPTION
Hi,

Building an ObjectMap in a purely functional way can be very expensive since insertions take O(n) time.
So, I added a module to be able to manipulate mutable ObjectMaps via the ST monad.

I have also removed non exported modules in test/Main.purs, created a file test.dhall and removed libraries from spago.dhall that only concern tests.
You can run test via `spago test -x test.dhall`